### PR TITLE
📦 Bump versions of multiple dependencies to address vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "standard": "^9.0.2",
     "standard-version": "^4.0.0",
     "micromatch": "4.0.8",
-    "babel-traverse": "7.23.2"
+    "babel-traverse": "7.23.2",
+    "braces": "3.0.3"
   },
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "nyc": "^11.1.0",
     "pmock": "^0.2.3",
     "standard": "^9.0.2",
-    "standard-version": "^4.0.0"
+    "standard-version": "^4.0.0",
+    "micromatch": "4.0.8"
   },
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "pmock": "^0.2.3",
     "standard": "^9.0.2",
     "standard-version": "^4.0.0",
-    "micromatch": "4.0.8"
+    "micromatch": "4.0.8",
+    "babel-traverse": "7.23.2"
   },
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",


### PR DESCRIPTION
Lineaje has automatically created this pull request to resolve the following CVEs:
| Component | CVE ID  | Severity | Description       |
|-------|-------|-----|-----------|
| npm:braces:1.8.5 | CVE-2024-4068 | High  | The NPM package `braces` fails to limit the number of<br>characters it can handle, which could lead to Memory<br>Exhaustion. In `lib/parse.js,` if a malicious user sends<br>"imbalanced braces" as input, the parsing will enter a loop,<br>which will cause the program to start allocating heap memory<br>without freeing it at any moment of the loop. Eventually, the<br>JavaScript heap limit is reached, and the program will crash. |
| npm:braces:1.8.5 | CVE-2018-1109 | Low  | A vulnerability was found in Braces versions prior to 2.3.1.<br>Affected versions of this package are vulnerable to Regular<br>Expression Denial of Service (ReDoS) attacks. |
| npm:braces:1.8.5 | GHSA-g95f-p29q-9xw4 | Low  | Regular Expression Denial of Service in braces |
| npm:micromatch:2.3.11 | CVE-2024-4067 | Medium  | The NPM package `micromatch` prior to version 4.0.8 is<br>vulnerable to Regular Expression Denial of Service (ReDoS).<br>The vulnerability occurs in `micromatch.braces()` in<br>`index.js` because the pattern `.*` will greedily match<br>anything. By passing a malicious payload, the pattern<br>matching will keep backtracking to the input while it doesn't<br>find the closing bracket. As the input size increases, the<br>consumption time will also increase until it causes the<br>application to hang or slow down. There was a merged fix but<br>further testing shows the issue persisted prior to<br>https://github.com/micromatch/micromatch/pull/266. This issue<br>should be mitigated by using a safe pattern that won't start<br>backtracking the regular expression due to greedy matching. |
| npm:babel-traverse:6.26.0 | CVE-2023-45133 | Critical  | ### Impact Using Babel to compile code that was specifically<br>crafted by an attacker can lead to arbitrary code execution<br>during compilation, when using plugins that rely on the<br>`path.evaluate()`or `path.evaluateTruthy()` internal Babel<br>methods. Known affected plugins are: -<br>`@babel/plugin-transform-runtime` - `@babel/preset-env` when<br>using its<br>[`useBuiltIns`](https://babeljs.io/docs/babel-preset-env#usebuiltins)<br>option - Any "polyfill provider" plugin that depends on<br>`@babel/helper-define-polyfill-provider`, such as<br>`babel-plugin-polyfill-corejs3`,<br>`babel-plugin-polyfill-corejs2`,<br>`babel-plugin-polyfill-es-shims`,<br>`babel-plugin-polyfill-regenerator` No other plugins under<br>the `@babel/` namespace are impacted, but third-party plugins<br>might be. **Users that only compile trusted code are not<br>impacted.** ### Patches The vulnerability has been fixed in<br>`@babel/traverse@7.23.2`. Babel 6 does not receive security<br>fixes anymore (see [Babel's security<br>policy](https://github.com/babel/babel/security/policy)),<br>hence there is no patch planned for `babel-traverse@6`. ###<br>Workarounds - Upgrade `@babel/traverse` to v7.23.2 or higher.<br>You can do this by deleting it from your package manager's<br>lockfile and re-installing the dependencies. `@babel/core`<br>>=7.23.2 will automatically pull in a non-vulnerable version.<br>- If you cannot upgrade `@babel/traverse` and are using one<br>of the affected packages mentioned above, upgrade them to<br>their latest version to avoid triggering the vulnerable code<br>path in affected `@babel/traverse` versions: -<br>`@babel/plugin-transform-runtime` v7.23.2 -<br>`@babel/preset-env` v7.23.2 -<br>`@babel/helper-define-polyfill-provider` v0.4.3 -<br>`babel-plugin-polyfill-corejs2` v0.4.6 -<br>`babel-plugin-polyfill-corejs3` v0.8.5 -<br>`babel-plugin-polyfill-es-shims` v0.10.0 -<br>`babel-plugin-polyfill-regenerator` v0.5.3 |

You can merge this PR once the tests pass and the changes are reviewed.

Thank you for reviewing the update! :rocket:
